### PR TITLE
Fix drawing to canvases with dimensions not equal to the window

### DIFF
--- a/talkies.lua
+++ b/talkies.lua
@@ -205,7 +205,15 @@ function Talkies.draw()
   love.graphics.push()
   love.graphics.setDefaultFilter("nearest", "nearest")
 
-  local windowWidth, windowHeight = love.graphics.getDimensions( )
+  local function getDimensions()
+    local canvas = love.graphics.getCanvas()
+    if canvas then
+      return canvas:getDimensions()
+    end
+    return love.graphics.getDimensions()
+  end
+
+  local windowWidth, windowHeight = love.graphics.getDimensions()
 
   -- message box
   local boxW = windowWidth-(2*currentDialog.padding)


### PR DESCRIPTION
Presently, if you attempt to use talkies by, say, rendering it to a canvas and then upscaling the canvas to draw to the window, then talkies will use the window's dimensions when drawing onto the canvas, resulting in the textbox displaying in an incorrect location or off of the screen. This fixes that problem by way of a short `getDimensions` helper function, which will return the dimensions of the canvas being rendered to if it is being rendered to a canvas, or the window dimensions otherwise.