### PR TITLE
Fix handling of messages containing single dashes

### DIFF
--- a/talkies.lua
+++ b/talkies.lua
@@ -54,13 +54,13 @@ end
 
 function Typer:resume()
   if not self.paused then return end
-  self.msg = self.msg:gsub("-+", " ", 1)
+  self.msg = self.msg:gsub("%-%-", " ", 1)
   self.paused = false
 end
 
 function Typer:finish()
   if self.complete then return end
-  self.visible = self.msg:gsub("-+", " ")
+  self.visible = self.msg:gsub("%-%-", " ")
   self.complete = true
 end
 


### PR DESCRIPTION
Previously, if a message contained single dashes and no double dashes, hitting the onAction button would cause the dashes to be replaced with spaces, but letting the message finish displaying on its own would leave the dashes alone. Let's always leave the dashes alone!