### PR TITLE
Borders, Rounding, Higher Text Speeds, and More

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ The following are all of the message theme options:
 * `optionSwitchSound` - Sound to be played when a option is selected
 * `indicatorCharacter` - Character on the bottom right indicating more content (string), default: ">"
 * `optionCharacter` - Character before option to indicate selection (string), default: "-"
+* `inlineOptions` - Sets whether options should be displayed within the message box or if they should be displayed in a separate box, default: `true`
 * `font` - Message box font (e.g. `Talkies.font = love.graphics.newFont("Talkies/main.ttf", 32)`)
 * `padding` - padding on the inside of the box, default is `10`
 * `thickness` - thickness of box borders. Default is `0` (no border).

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ end
 ### Talkies.say(title, messages, config)
 Create a new dialog of messages and returns that dialog.
 
-- **title** : string
+- **title** : string; if set to `""`, title box will not appear
 - **messages**, a string or a table that contains strings
 - **config**, table that contains message configs, takes;
   * `image`, message icon image e.g. `love.graphics.newImage("img.png")`
@@ -108,20 +108,24 @@ you wanted a single message to go slower you would create it like this.
 `Talkies.say("Old man", "I talk very slow", {textSpeed = "slow"})`
 
 The following are all of the message theme options:
-* `textSpeed`, speed that the text is displayed. `slow`, `medium`, `fast` or number, default to fast.
+* `textSpeed` - speed that the text is displayed. `slow`, `medium`, `fast` or number, default to fast.
 * `talkSound` - Sound to be played when the character speaks, should be a very short clip (e.g. `Talkies.typeSound = love.audio.newSource("typeSound.wav", "static")`)
 * `optionSwitchSound` - Sound to be played when a option is selected
 * `indicatorCharacter` - Character on the bottom right indicating more content (string), default: ">"
 * `optionCharacter` - Character before option to indicate selection (string), default: "-"
 * `font` - Message box font (e.g. `Talkies.font = love.graphics.newFont("Talkies/main.ttf", 32)`)
 * `padding` - padding on the inside of the box, default is `10`
-* `titleColor`, title text color.
-* `messageColor`, message text color. Default is `{1, 1, 1}`
-* `backgroundColor`, background color of the box. Default is `{0, 0, 0, 0.8}`
-* `typedNotTalked`, when making a sound while talking, if this is set to true the
+* `thickness` - thickness of box borders. Default is `0` (no border).
+* `titleColor` - title text color. Default is `{1, 1, 1}` (when `nil`, uses message text color).
+* `titleBackgroundColor` - background color for title box. Default is `nil` (when `nil`, uses message background color).
+* `titleBorderColor` - border color for title box. Default is `nil` (when `nil`, uses message border color).
+* `messageColor` - message text color. Default is `{1, 1, 1}`
+* `messageBackgroundColor` - background color of the message box. Default is `{0, 0, 0, 0.8}`
+* `messageBorderColor` - border color of the message box. Default is `nil` (when `nil`, uses message background color).
+* `typedNotTalked` - when making a sound while talking, if this is set to true the
   noise will be made for every character. If set to false the noise will be looped,
   and the pitch will be oscillated randomly between the pitchValues setting. default to true
-* `pitchValues`, If `typedNotTalked` is set to false then this table value will be
+* `pitchValues` - If `typedNotTalked` is set to false then this table value will be
   used to choose values of pitch while talking. If you want no pitch change set it to
   {1}, Default is {0.7, 0.8, 1.0, 1.2, 1.3}
 

--- a/talkies.lua
+++ b/talkies.lua
@@ -69,17 +69,17 @@ function Typer:update(dt)
   if self.complete then return typed end
   if not self.paused then
     self.timer = self.timer - dt
-    while not self.paused and self.timer <= 0 and self.position < #self.msg + 1 do
+    while not self.paused and not self.complete and self.timer <= 0 do
       typed = string.sub(self.msg, self.position, self.position) ~= " "
       self.position = self.position + 1
       
       self.timer = self.timer + self.max
       self.visible = string.sub(self.msg, 0, utf8.offset(self.msg, self.position) - 1)
+      self.complete = (self.visible == self.msg)
       self.paused = string.sub(self.msg, string.len(self.visible)+1, string.len(self.visible)+2) == "--"
     end
   end
   
-  self.complete = (self.visible == self.msg)
   return typed
 end
 

--- a/talkies.lua
+++ b/talkies.lua
@@ -69,15 +69,17 @@ function Typer:update(dt)
   if self.complete then return typed end
   if not self.paused then
     self.timer = self.timer - dt
-    if self.timer <= 0 then
+    while not self.paused and self.timer <= 0 and self.position < #self.msg + 1 do
       typed = string.sub(self.msg, self.position, self.position) ~= " "
       self.position = self.position + 1
-      self.timer = self.max
+      
+      self.timer = self.timer + self.max
+      self.visible = string.sub(self.msg, 0, utf8.offset(self.msg, self.position) - 1)
+      self.paused = string.sub(self.msg, string.len(self.visible)+1, string.len(self.visible)+2) == "--"
     end
   end
-  self.visible = string.sub(self.msg, 0, utf8.offset(self.msg, self.position) - 1)
+  
   self.complete = (self.visible == self.msg)
-  self.paused = string.sub(self.msg, string.len(self.visible)+1, string.len(self.visible)+2) == "--"
   return typed
 end
 


### PR DESCRIPTION
I've made a lot of changes of various sizes to Talkies. Here's a list.

### Changes

- Characters are now typed in messages in a loop while the `Typer.timer` count is less than 0, meaning that characters can be typed at any speed instead of being capped at roughly `1/60` (one character per frame or 60 characters per second). Now, setting `textSpeed` to 0 will type the entire message instantly.
  - `textSpeed` now defaults to `1/60`, approximately matching the previous default speed of one character per frame.
  - Typing loop works correctly with pauses.
- Options are now shown in a box in the center of the screen rather than layered over the message box to solve issues with option text overlapping with message box text or flowing offscreen. This box shares appearance traits with the main message box, is centered horizontally and positioned vertically between the top of the screen and the top of the message box, and is sized automatically to fit the provided options.
- `titleColor` can now be set to `nil`, in which case `titleColor` will be set to match `messageColor`
- Message and title boxes can now have different background colors
  - `backgroundColor` is renamed to `messageBackgroundColor`
  - `titleBackgroundColor` is added as a field for the color of the title box; if this field is left as `nil`, it will be set to `messageBackgroundColor`
- Message and title boxes can now have outlines/borders
  - `thickness` field has been added, which is the thickness in pixels of the border; if set to `0`, there will be no border.
  - `messageBorderColor` is added as a field controlling the color of the message box border; if set to `nil`, defaults to `messageBackgroundColor`
  - `titleBorderColor` is added as a field controlling the title box border; if set to `nil`, defaults to `messageBorderColor`
- Message and title boxes can now have rounded corners
  - `rounding` field is added, which controls the radius in pixels of the rounded corners; if set to `0`, there will be no rounding.
- `title` can now be set to an empty string (`""`), which will prevent the title box from being drawn. This is useful for narration sections, internal dialogue, and other purposes.
- README.md updated with new configuration options.
- Minor fixes to inconsistent use of commas and dashes in README.md.
- Minor correction of `love.graphics.setColor(255, 255, 255)` to `love.graphics.setColor(1, 1, 1)` in the message avatar section to match the new color scale implemented in Love2D 11.0.