### PR TITLE
Message text horizontally autowraps before typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ The following are all of the message theme options:
 * `font` - Message box font (e.g. `Talkies.font = love.graphics.newFont("Talkies/main.ttf", 32)`)
 * `padding` - padding on the inside of the box, default is `10`
 * `thickness` - thickness of box borders. Default is `0` (no border).
+* `rounding` - radius in pixels of box corners. Default is `0` (no rounding).
 * `titleColor` - title text color. Default is `{1, 1, 1}` (when `nil`, uses message text color).
 * `titleBackgroundColor` - background color for title box. Default is `nil` (when `nil`, uses message background color).
 * `titleBorderColor` - border color for title box. Default is `nil` (when `nil`, uses message border color).

--- a/talkies.lua
+++ b/talkies.lua
@@ -298,7 +298,13 @@ function Talkies.draw()
 
   -- Message text
   love.graphics.setColor(currentDialog.messageColor)
-  love.graphics.printf(currentMessage.visible, textX, textY, boxW - imgW - (4 * currentDialog.padding))
+  local textW = boxW - imgW - (4 * currentDialog.padding)
+  local _, modmsg = currentDialog.font:getWrap(currentMessage.msg, textW)
+  local catmsg = table.concat(modmsg, "\n")
+  
+  local display = string.sub(catmsg, 1, #currentMessage.visible + #modmsg - 1)
+  
+  love.graphics.print(display, textX, textY)
 
   -- Message options (when shown)
   if currentDialog:showOptions() and currentMessage.complete then


### PR DESCRIPTION
Previously, when messages were typed, words at the end of a line would be partially typed until they would overflow horizontally, at which point love.graphics.printf would wrap it to the next line. This is shown in the following gif:

![OldTalkiesWrapping](https://user-images.githubusercontent.com/75563718/102451463-229eaf00-3ffe-11eb-9a01-0eeaa12accd2.gif)

This branch replaces this method to instead use Love2D's Font:getWrap() function to automatically wrap the text before displaying. This is shown in the following gif:

![NewTalkiesWrapping](https://user-images.githubusercontent.com/75563718/102451672-9345cb80-3ffe-11eb-9dc8-c738bef88c25.gif)

As well, I've added the previously-forgotten rounding attribute to README.md.