### PR TITLE
Fix for text skip no longer removing pause dashes

### DIFF
--- a/talkies.lua
+++ b/talkies.lua
@@ -60,7 +60,8 @@ end
 
 function Typer:finish()
   if self.complete then return end
-  self.visible = self.msg:gsub("%-%-", " ")
+  self.msg = self.msg:gsub("%-%-", " ")
+  self.visible = self.msg
   self.complete = true
 end
 


### PR DESCRIPTION
As a result of the change which added automatic wrapping, I introduced a bug in which double-dash pauses would not be removed from the message if the player skipped to the end of the dialog. This is because the displayed text would be created from `Typer.msg`, but skipping to the end of the message would only update `Typer.visible`. This branch fixes this bug by updating both `Typer.visible` and `Typer.msg` when the message is skipped.