### PR TITLE
Fixes crash for UTF8 characters in messages that take more than one line

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ below
 
 #### Pauses
 A double dash `--` causes them message to stop typing, and will only continue when
-`Talkies.selectButton` is pressed, each `--` will be replaced with a space.
+`Talkies.selectButton` is pressed. (Be sure to follow each `--` with a space if you
+want text to wrap correctly!)
 
 ### Talkies.update(dt)
 Update will update the UI with the dt and animate the typing

--- a/example/main.lua
+++ b/example/main.lua
@@ -55,7 +55,7 @@ end
 
 function love.keypressed(key)
   if key == "c" then Talkies.clearMessages()
-  elseif key == "m" then Talkies.say("Title", "Message one", "two", "and three...", {onstart=function() rand() end})
+  elseif key == "m" then Talkies.say("Title", {"Message one", "two", "and three..."}, {onstart=function() rand() end})
   elseif key == "escape" then love.event.quit()
   elseif key == "space" then Talkies.onAction()
   elseif key == "up" then Talkies.prevOption()

--- a/example/other.lua
+++ b/example/other.lua
@@ -17,7 +17,7 @@ function Obey.sayHello()
   Talkies.say( "Tutorial",
     {
       "Talkies is a simple to use messagebox library, it includes;",
-      "Multiple choices,--UTF8 text,--Pauses,--Onstart/OnMessage/Oncomplete functions,--Complete customization,--Variable typing speeds umongst other things."
+      "Multiple choices,-- UTF8 text,-- Pauses,-- Onstart/OnMessage/Oncomplete functions,-- Complete customization,-- Variable typing speeds amongst other things."
     },
     {
       image=avatar,

--- a/talkies.lua
+++ b/talkies.lua
@@ -78,15 +78,16 @@ end
 
 function Typer:resume()
   if not self.paused then return end
-  self.msg = self.msg:gsub("%-%-", " ", 1)
-  self.strip = self.strip:gsub("%-%-", " ", 1)
+  self.msg = self.msg:gsub("%-%-", "", 1)
+  self.strip = self.strip:gsub("%-%-", "", 1)
   self.paused = false
 end
 
 function Typer:finish()
   if self.complete then return end
-  self.msg = self.msg:gsub("%-%-", " ")
-  self.position = utf8.len(self.msg)
+  self.msg = self.msg:gsub("%-%-", "")
+  self.strip = self.strip:gsub("%-%-", "")
+  self.position = utf8.len(self.strip)
   self.complete = true
 end
 


### PR DESCRIPTION
fixes #14
 
* Fixed issue #14 through the use of a new typing system. This new system draws each line of text individually.
   * This issue was my fault, as I had forgotten to include `utf8.offset` when getting the substring of the message. However, fixing this revealed a further issue, which is that concatenating the word-wrapped lines of text changed the length and content of the string being printed to the screen. This would, in every method I tested, result in some sort of misalignment from where the typing position should be and where it actually was. Now, by not counting newlines in the length of messages, displayed text will be the correct length regardless of how many word-wrap newlines are added.
 * Replaced all instances of `string.sub` and `utf8.offset` with a helper function called `utf8.sub(str, start, stop)`, which returns a substring of `str` starting and stopping at character (not byte) indices `start` and `stop` inclusively.
 * Removed `Typer.visible`, as the displayed text is generated per frame depending on window size.
 * New property `Typer.strip`, which contains the `Typer`'s message, except with newlines removed.
   * `Typer.position` now refers to the typing position in `Typer.strip` rather than `Typer.msg`. This change results in newlines being printed instantly. As a result, no matter how wide or thin the window is, the same message will always take the same amount of time to type with the same typing speed.
 * `Typer.complete` is now set to true when `Typer.position` reaches the end of `Typer.strip` .
 * Fixed a minor issue in which `Typer.position` started at 0 instead of 1, which caused the first character to take twice as long to type as the rest.
 * Fixed an error in the example code; now, when "m" is pressed, "Message one" will be correctly followed by "two" and "and three...", as well as properly running the `onstart` function.
 * Added spaces after each pause in the example code feature list (without spaces, `Font:getWrap()` considers the consecutive items to be one long word, causing incorrect line wrapping).