### PR TITLE
Reset color after drawing messages

### DIFF
--- a/talkies.lua
+++ b/talkies.lua
@@ -395,6 +395,9 @@ function Talkies.draw()
   end
 
   love.graphics.pop()
+
+  -- Reset color so other draw operations won't be affected
+  love.graphics.setColor(1, 1, 1, 1)
 end
 
 function Talkies.prevOption()


### PR DESCRIPTION
I noticed that when I change the message color to black, the color from `love.graphics.setColor()` will affect all subsequent draw operations, i.e. the screen turns completely black after the dialogue is displayed.

Adding this line to reset the color prevents this issue. 